### PR TITLE
Potential fix for code scanning alert no. 25: Server-side request forgery

### DIFF
--- a/src-ssr/middlewares/gdriveProxy.ts
+++ b/src-ssr/middlewares/gdriveProxy.ts
@@ -42,8 +42,9 @@ const fetchGoogleDriveFile = async (fileId: string, res: Response) => {
 const handleProxyRequest = async (req: Request, res: Response) => {
   const fileId = req.params.fileId
 
-  if (!fileId) {
-    return res.status(400).json({ error: 'Missing fileId parameter' })
+  const fileIdPattern = /^[a-zA-Z0-9_-]+$/;
+  if (!fileId || !fileIdPattern.test(fileId)) {
+    return res.status(400).json({ error: 'Invalid fileId parameter' })
   }
 
   await fetchGoogleDriveFile(fileId, res)

--- a/yarn.lock
+++ b/yarn.lock
@@ -9568,9 +9568,9 @@ elementtree@0.1.7:
     sax "1.1.4"
 
 elliptic@^6.5.3, elliptic@^6.5.5:
-  version "6.5.7"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
-  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
Potential fix for [https://github.com/Xyntopia/taskyon/security/code-scanning/25](https://github.com/Xyntopia/taskyon/security/code-scanning/25)

To fix the problem, we need to validate and sanitize the `fileId` parameter before using it in the URL for the `axios.get` request. The best way to do this is to ensure that the `fileId` conforms to the expected format for Google Drive file IDs, which are typically alphanumeric strings. We can use a regular expression to validate the `fileId` and reject any input that does not match the expected pattern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
