### PR TITLE
Potential fix for code scanning alert no. 24: Type confusion through parameter tampering

### DIFF
--- a/src/modules/encoding.ts
+++ b/src/modules/encoding.ts
@@ -46,7 +46,10 @@ export function uint8ArrayToBase64Url(uint8Array: Uint8Array) {
     .replace(/=+$/, '') // Remove trailing '='
 }
 
-export function base64UrlToUint8Array(base64UrlString: string) {
+export function base64UrlToUint8Array(base64UrlString: unknown) {
+  if (typeof base64UrlString !== 'string') {
+    throw new TypeError('Expected base64UrlString to be a string');
+  }
   // Add padding '=' if necessary
   const padding = '='.repeat((4 - (base64UrlString.length % 4)) % 4)
   const base64 =


### PR DESCRIPTION
Potential fix for [https://github.com/Xyntopia/taskyon/security/code-scanning/24](https://github.com/Xyntopia/taskyon/security/code-scanning/24)

To fix the problem, we need to ensure that the `base64UrlString` parameter is of type `string` before processing it. This can be done by adding a type check at the beginning of the `base64UrlToUint8Array` function. If the parameter is not a string, we should handle the error appropriately, such as by throwing an error or returning a default value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
